### PR TITLE
change type of OverlayOptions.position

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5847,7 +5847,7 @@ declare global {
          */
         export  interface OverlayOptions {
             map?: Map_2;
-            position?: Vector2;
+            position?: Vector2 | LngLat;
             content?: string | HTMLElement;
             visible?: boolean;
             zIndex?: number;


### PR DESCRIPTION
[AMap.Marker](https://lbs.amap.com/api/jsapi-v2/documentation#marker)的接口文档中说明了其构造参数中的对象的属性值 `opts.position` 的类型为 `(Vector2 | LngLat)` ，实际开发中也是如此，但是 `index.d.ts` 的定义中只实现了 `position?: Vector2;` ，对此需将其类型变为联合类型 `position?: Vector2 | LngLat;` 。