### PR TITLE
fix: polygon-editor 类型声明文件路径错误

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -989,6 +989,43 @@ declare global {
 
 
     /**
+     * 
+     * 鹰眼的初始化参数
+     * 
+     * @public
+     */
+    export interface HawkEyeOptions {
+      autoMove?: boolean; // 是否随主图视口变化移动
+      showRectangle?: boolean; // 是否显示视口矩形
+      showButton?: boolean; // 是否显示打开关闭的按钮
+      isOpen?: boolean; // 默认是否展开
+      mapStyle?: string; // 缩略图要显示的地图自定义样式，如'amap://styles/dark'
+      layers?: any[]; // 缩略图要显示的图层类型，默认为普通矢量地图
+      width?: string; // 缩略图的宽度，同CSS，如'200px'
+      height?: string; // 缩略图的高度，同CSS，如'200px'
+      offset?: [number, number]; // 缩略图距离地图右下角的像素距离，如 [2,2]
+      borderStyle?: string; // 缩略图的边框样式，同CSS，如"double solid solid double"
+      borderColor?: string; // 缩略图的高度，同CSS，如'silver'
+      borderRadius?: string; // 缩略图的高度，同CSS，如'5px'
+      borderWidth?: string; // 缩略图的高度，同CSS，如'2px'
+      buttonSize?: string; // 箭头按钮的像素尺寸，同CSS，如'12px'
+    }
+
+    /**
+     * 鹰眼控件，用于显示缩略地图，显示于地图右下角，可以随主图的视口变化而变化，也可以配置成固定位置实现类似于南海附图的效果
+     * https://lbs.amap.com/api/javascript-api-v2/documentation#hawkeye
+     * 
+     * @public
+     * @param {HawkEyeOptions} options
+     * @class HawkEye
+     * @extends {Control}
+     */
+    export class HawkEye extends AMap.Control {
+      constructor(options?: HawkEyeOptions);
+    }
+
+
+    /**
      * 图层信息，需要包含图层对象
      * 
      * @public

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ import { _Heatmap } from "./plugins/Heatmap";
 import { _MarkerClusterer } from "./plugins/MarkerClusterer";
 import { _RangingTool } from "./plugins/RangingTool";
 import { _PolygonEditor } from "./plugins/PolygonEditor";
-import { _PolylineEditor } from "./plugins/PolylIneEditor";
+import { _PolylineEditor } from "./plugins/PolylineEditor";
 
 declare global {
   interface Window {


### PR DESCRIPTION
该问题在 mac 这类默认忽视大小写的环境下可能不会提现出来