### PR TITLE
fix: 导入 PolylineEditor 类型的路径大小写错误

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ import { _Heatmap } from "./plugins/Heatmap";
 import { _MarkerClusterer } from "./plugins/MarkerClusterer";
 import { _RangingTool } from "./plugins/RangingTool";
 import { _PolygonEditor } from "./plugins/PolygonEditor";
-import { _PolylineEditor } from "./plugins/PolylIneEditor";
+import { _PolylineEditor } from "./plugins/PolylineEditor";
 
 declare global {
   interface Window {


### PR DESCRIPTION
该问题在 mac 这类默认忽视大小写的环境下可能不会提现出来